### PR TITLE
Add error export and configurable question count

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -67,7 +67,7 @@ def generate_sentence_batch(cefr, target_language, module):
     lines = [
         re.sub(r"^\d+[\).]\s*", "", l).strip() for l in text.splitlines() if l.strip()
     ]
-    unique_lines = list(dict.fromkeys(lines))
+    unique_lines = list(dict.fromkeys(lines[1:-1])) # remove chatgpt filler
     random.shuffle(unique_lines)
     return unique_lines[:5]
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ function App() {
   const [language, setLanguage] = useState("");
   const [cefr, setCefr] = useState("A1");
   const [module, setModule] = useState("");
+  const [questionCount, setQuestionCount] = useState(5);
   const [screen, setScreen] = useState("home");
 
   const login = (selectedUser) => {
@@ -35,6 +36,8 @@ function App() {
           cefr={cefr}
           setCefr={setCefr}
           setModule={setModule}
+          questionCount={questionCount}
+          setQuestionCount={setQuestionCount}
           next={() => setScreen("practice")}
         />
       );
@@ -45,6 +48,7 @@ function App() {
           language={language}
           cefr={cefr}
           module={module}
+          questionCount={questionCount}
           onComplete={() => setScreen("summary")}
         />
       );

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -48,12 +48,22 @@ function ModuleScreen({
       </div>
       <div style={{ margin: "1rem 0" }}>
         <label>
-          Number of questions: {" "}
+          Number of questions:{" "}
           <input
             type="number"
             min="1"
-            value={questionCount}
-            onChange={(e) => setQuestionCount(parseInt(e.target.value) || 5)}
+            value={questionCount === null ? "" : questionCount}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === "") {
+                setQuestionCount(null); // allow clearing
+              } else {
+                const parsed = parseInt(value);
+                if (!isNaN(parsed)) {
+                  setQuestionCount(parsed);
+                }
+              }
+            }}
           />
         </label>
       </div>

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -1,7 +1,16 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 
-function ModuleScreen({ user, language, cefr, setCefr, setModule, next }) {
+function ModuleScreen({
+  user,
+  language,
+  cefr,
+  setCefr,
+  setModule,
+  questionCount,
+  setQuestionCount,
+  next,
+}) {
   const [modules, setModules] = useState([]);
   const [search, setSearch] = useState("");
 
@@ -36,6 +45,17 @@ function ModuleScreen({ user, language, cefr, setCefr, setModule, next }) {
             {lvl}
           </label>
         ))}
+      </div>
+      <div style={{ margin: "1rem 0" }}>
+        <label>
+          Number of questions: {" "}
+          <input
+            type="number"
+            min="1"
+            value={questionCount}
+            onChange={(e) => setQuestionCount(parseInt(e.target.value) || 5)}
+          />
+        </label>
       </div>
       <input
         value={search}

--- a/frontend/src/components/SessionSummary.js
+++ b/frontend/src/components/SessionSummary.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 function SessionSummary({ restart, home, user }) {
   const [filename, setFilename] = useState('session.csv');
+  const [errorsFilename, setErrorsFilename] = useState('errors.csv');
 
   const download = async () => {
     try {
@@ -19,6 +20,22 @@ function SessionSummary({ restart, home, user }) {
     }
   };
 
+  const downloadErrors = async () => {
+    try {
+      const response = await fetch(`/session/${user.id}/errors`);
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = errorsFilename || 'errors.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("❌ Failed to download errors CSV:", err);
+    }
+  };
+
   return (
     <div style={{ padding: '2rem' }}>
       <h2>🎉 Congrats!</h2>
@@ -31,6 +48,15 @@ function SessionSummary({ restart, home, user }) {
           style={{ marginRight: '1rem' }}
         />
         <button onClick={download}>Download CSV</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <input
+          value={errorsFilename}
+          onChange={e => setErrorsFilename(e.target.value)}
+          placeholder="Errors filename (e.g., errors.csv)"
+          style={{ marginRight: '1rem' }}
+        />
+        <button onClick={downloadErrors}>Download Errors</button>
       </div>
       <div style={{ marginTop: '1rem' }}>
         <button onClick={restart} style={{ marginRight: '1rem' }}>Continue</button>


### PR DESCRIPTION
## Summary
- allow exporting error CSVs from backend
- make question count configurable in module screen
- update practice session flow with next steps
- add error download option to session summary

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684da4454ff88331b2220538dee68ccd