### PR TITLE
Add personalized module flow and navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,9 +1,12 @@
 import React, { useState } from "react";
+import axios from "axios";
 import HomePage from "./components/HomePage";
 import LanguageSelector from "./components/LanguageSelector";
 import ModuleScreen from "./components/ModuleScreen";
 import PracticeSession from "./components/PracticeSession";
 import SessionSummary from "./components/SessionSummary";
+import ExportPage from "./components/ExportPage";
+import PersonalizedTopics from "./components/PersonalizedTopics";
 
 function App() {
   const [user, setUser] = useState(null);
@@ -12,6 +15,8 @@ function App() {
   const [module, setModule] = useState("");
   const [questionCount, setQuestionCount] = useState(5);
   const [screen, setScreen] = useState("home");
+  const [topicOptions, setTopicOptions] = useState([]);
+  const [selectedTopics, setSelectedTopics] = useState([]);
 
   const login = (selectedUser) => {
     setUser(selectedUser);
@@ -26,6 +31,8 @@ function App() {
         <LanguageSelector
           onSelect={setLanguage}
           next={() => setScreen("module")}
+          goExport={() => setScreen("export")}
+          home={() => setScreen("home")}
         />
       );
     case "module":
@@ -39,6 +46,11 @@ function App() {
           questionCount={questionCount}
           setQuestionCount={setQuestionCount}
           next={() => setScreen("practice")}
+          startPersonalized={(topics) => {
+            setTopicOptions(topics);
+            setScreen("personalized-topics");
+          }}
+          home={() => setScreen("home")}
         />
       );
     case "practice":
@@ -50,6 +62,30 @@ function App() {
           module={module}
           questionCount={questionCount}
           onComplete={() => setScreen("summary")}
+          home={() => setScreen("home")}
+        />
+      );
+    case "personalized-topics":
+      return (
+        <PersonalizedTopics
+          topics={topicOptions}
+          onNext={(list) => {
+            setSelectedTopics(list);
+            axios
+              .post("/personalized/preload", { language, cefr, topics: list })
+              .then(() => {
+                setModule("personalized");
+                setScreen("practice");
+              });
+          }}
+          home={() => setScreen("home")}
+        />
+      );
+    case "export":
+      return (
+        <ExportPage
+          home={() => setScreen("home")}
+          user={user}
         />
       );
     case "summary":

--- a/frontend/src/components/ExportPage.js
+++ b/frontend/src/components/ExportPage.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+function ExportPage({ home, user }) {
+  const [filename, setFilename] = useState('session.csv');
+  const [errorsFilename, setErrorsFilename] = useState('errors.csv');
+
+  const download = async () => {
+    try {
+      const response = await fetch(`/session/${user.id}/export`);
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename || 'session.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('❌ Failed to download CSV:', err);
+    }
+  };
+
+  const downloadErrors = async () => {
+    try {
+      const response = await fetch(`/session/${user.id}/errors`);
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = errorsFilename || 'errors.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('❌ Failed to download errors CSV:', err);
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Session Export</h2>
+      <div style={{ marginTop: '1rem' }}>
+        <input
+          value={filename}
+          onChange={e => setFilename(e.target.value)}
+          placeholder="Filename (e.g., my-session.csv)"
+          style={{ marginRight: '1rem' }}
+        />
+        <button onClick={download}>Download CSV</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <input
+          value={errorsFilename}
+          onChange={e => setErrorsFilename(e.target.value)}
+          placeholder="Errors filename (e.g., errors.csv)"
+          style={{ marginRight: '1rem' }}
+        />
+        <button onClick={downloadErrors}>Download Errors</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={home}>Home</button>
+      </div>
+    </div>
+  );
+}
+
+export default ExportPage;

--- a/frontend/src/components/LanguageSelector.js
+++ b/frontend/src/components/LanguageSelector.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function LanguageSelector({ onSelect, next }) {
+function LanguageSelector({ onSelect, next, goExport, home }) {
   const choose = lang => {
     onSelect(lang);
     next();
@@ -11,6 +11,10 @@ function LanguageSelector({ onSelect, next }) {
       <h2>Select Language</h2>
       <button onClick={() => choose('French')}>French</button>
       <button onClick={() => choose('Spanish')}>Spanish</button>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={goExport} style={{ marginRight: '1rem' }}>Session Export</button>
+        <button onClick={home}>Home</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -10,6 +10,8 @@ function ModuleScreen({
   questionCount,
   setQuestionCount,
   next,
+  startPersonalized,
+  home,
 }) {
   const [modules, setModules] = useState([]);
   const [search, setSearch] = useState("");
@@ -29,6 +31,14 @@ function ModuleScreen({
     axios
       .post("/sentence/preload", { language, cefr, module: m })
       .then(() => next());
+  };
+
+  const personalized = () => {
+    axios
+      .post('/personalized/topics', { user_id: user.id, language })
+      .then(res => {
+        startPersonalized(res.data.topics || []);
+      });
   };
 
   return (
@@ -79,6 +89,12 @@ function ModuleScreen({
           </li>
         ))}
       </ul>
+      <div style={{ marginTop: "1rem" }}>
+        <button onClick={personalized} style={{ marginRight: "1rem" }}>
+          Personalized Module based on Past errors
+        </button>
+        <button onClick={home}>Home</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/PersonalizedTopics.js
+++ b/frontend/src/components/PersonalizedTopics.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+function PersonalizedTopics({ topics, onNext, home }) {
+  const [items, setItems] = useState(topics.map(t => ({ text: t, checked: true })));
+  const [newTopic, setNewTopic] = useState('');
+
+  const toggle = index => {
+    const list = [...items];
+    list[index].checked = !list[index].checked;
+    setItems(list);
+  };
+
+  const add = () => {
+    const t = newTopic.trim();
+    if (t) {
+      setItems([...items, { text: t, checked: true }]);
+      setNewTopic('');
+    }
+  };
+
+  const next = () => {
+    onNext(items.filter(i => i.checked).map(i => i.text));
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Select Topics</h2>
+      <ul>
+        {items.map((item, idx) => (
+          <li key={idx}>
+            <label>
+              <input type="checkbox" checked={item.checked} onChange={() => toggle(idx)} />{' '}
+              {item.text}
+            </label>
+          </li>
+        ))}
+      </ul>
+      <div style={{ marginTop: '1rem' }}>
+        <input value={newTopic} onChange={e => setNewTopic(e.target.value)} placeholder="Add topic" />
+        <button onClick={add} style={{ marginLeft: '0.5rem' }}>Add</button>
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={next} style={{ marginRight: '1rem' }}>Next</button>
+        <button onClick={home}>Home</button>
+      </div>
+    </div>
+  );
+}
+
+export default PersonalizedTopics;

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
-function PracticeSession({ user, language, cefr, module, questionCount, onComplete }) {
+function PracticeSession({ user, language, cefr, module, questionCount, onComplete, home }) {
   const [sentence, setSentence] = useState('');
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
@@ -62,6 +62,9 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
         </>
       )}
       <div>Progress: {count}/{questionCount}</div>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={home}>Home</button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow exporting session data from the language selection screen
- add home button across the app for easier navigation
- add personalized module workflow based on recent user errors
- implement backend endpoints that surface frequent error topics and create sentence batches

## Testing
- `npm run build` (fails without node modules, then `npm install` and `npm run build` succeeds)
- `python -m py_compile backend/routes.py backend/app.py backend/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684da8e0f7cc8331a04b85a215c1f3a4