### PR TITLE
Add selective error saving

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -271,12 +271,13 @@ def export_session(user_id):
     )
     for s in sentences:
         explanation = s.openai_response.replace("\n", " ")
+        corrected = s.openai_response.split('.')[1] if (s.openai_response and len(s.openai_response.split('.')) > 1) else ""
         writer.writerow(
             [
                 s.timestamp,
                 s.english_text,
                 s.user_translation,
-                s.openai_response.splitlines()[1] if s.openai_response else "",
+                corrected,
                 explanation,
                 s.module.name,
                 s.module.language,

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -49,7 +49,6 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
   };
 
   const nextStep = () => {
-<<<<<<< HEAD
     const selected = errors.filter((_, idx) => checked[idx]);
     axios.post('/errors/save', { sentence_id: sentenceId, errors: selected })
       .then(() => {
@@ -64,15 +63,6 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
           fetchSentence();
         }
       });
-=======
-    if (count >= questionCount) {
-      onComplete(correctCount);
-    } else {
-      setAnswer('');
-      setResponse('');
-      fetchSentence();
-    }
->>>>>>> main
   };
 
   return (

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -5,6 +5,9 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
   const [sentence, setSentence] = useState('');
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
+  const [errors, setErrors] = useState([]);
+  const [checked, setChecked] = useState([]);
+  const [sentenceId, setSentenceId] = useState(null);
   const [count, setCount] = useState(0);
   const [stage, setStage] = useState('question'); // 'question' or 'result'
 
@@ -30,19 +33,29 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
       translation: answer,
     }).then(res => {
       setResponse(res.data.response);
+      setErrors(res.data.errors || []);
+      setChecked((res.data.errors || []).map(() => true));
+      setSentenceId(res.data.sentence_id);
       setCount(c => c + 1);
       setStage('result');
     });
   };
 
   const nextStep = () => {
-    if (count >= questionCount) {
-      onComplete();
-    } else {
-      setAnswer('');
-      setResponse('');
-      fetchSentence();
-    }
+    const selected = errors.filter((_, idx) => checked[idx]);
+    axios.post('/errors/save', { sentence_id: sentenceId, errors: selected })
+      .then(() => {
+        if (count >= questionCount) {
+          onComplete();
+        } else {
+          setAnswer('');
+          setResponse('');
+          setErrors([]);
+          setChecked([]);
+          setSentenceId(null);
+          fetchSentence();
+        }
+      });
   };
 
   return (
@@ -58,6 +71,29 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
       {stage === 'result' && (
         <>
           <pre>{response}</pre>
+          {errors.length > 0 && (
+            <div>
+              <h4>Select errors to save:</h4>
+              <ul>
+                {errors.map((err, idx) => (
+                  <li key={idx}>
+                    <label>
+                      <input
+                        type="checkbox"
+                        checked={checked[idx]}
+                        onChange={() => {
+                          const list = [...checked];
+                          list[idx] = !list[idx];
+                          setChecked(list);
+                        }}
+                      />{' '}
+                      {err}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <button onClick={nextStep}>Next</button>
         </>
       )}

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -53,7 +53,7 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
     axios.post('/errors/save', { sentence_id: sentenceId, errors: selected })
       .then(() => {
         if (count >= questionCount) {
-          onComplete();
+          onComplete(correctCount);
         } else {
           setAnswer('');
           setResponse('');


### PR DESCRIPTION
## Summary
- fetch corrections without saving errors immediately
- add endpoint to save selected errors
- enable checkbox selection of corrections in practice session UI

## Testing
- `python -m py_compile backend/routes.py`
- `python -m py_compile backend/*.py`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e1c9784f0833185a3c45ee4a119fb