### PR TITLE
Load modules from DB

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -142,22 +142,21 @@ def submit_sentence():
         ""
         #"Ex. "
     )
-    prompt = (
-        "Correct these, ignoring spelling errors.\n"
-        "Respond in the format: \n"
-        "<original french sentence> \n"
-        "<correct french sentence with only the corrections in bold>\n"
-        "<list of corrections with quick explanations, newline delimited>"
-        "\n"
-        "Ex. Our technical team is developing a secure digital portal for the bank’s lending services. - Notre equipe technique est en train de développer un interface digital securisé pour les services de prêt de la banque\n"
-        "\n"
-        "Notre equipe technique est en train de développer *une* interface *numérique* *sécurisée* pour les services de prêt de la banque\n"
-        "Explanation:\n"
-        "interface is feminine → une \n"
-        "digital → numérique is preferred in formal/technical French\n"
-        "securisé → sécurisée for feminine agreement"
-        )
-    prompt = f"{prompt}"
+    prompt = f"""
+            Correct these, ignoring spelling errors.
+            Respond in the format:
+            <original {language} sentence>
+            <correct {language} sentence with only the corrections in bold>
+            <list of corrections with quick explanations, newline delimited>
+
+            Ex. Our technical team is developing a secure digital portal for the bank’s lending services. - Notre equipe technique est en train de développer un interface digital securisé pour les services de prêt de la banque
+
+            Notre equipe technique est en train de développer *une* interface *numérique* *sécurisée* pour les services de prêt de la banque
+            Explanation:
+            interface is feminine → une
+            digital → numérique is preferred in formal/technical French
+            securisé → sécurisée for feminine agreement
+            """
     user_message = f"{english} - {translation}."
     full_prompt = prompt + "\n New submission \n" + user_message
     current_app.logger.info("OpenAI prompt: %s", full_prompt)

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -26,6 +26,14 @@ function ModuleScreen({
     m.toLowerCase().includes(search.toLowerCase()),
   );
 
+  const addModule = () => {
+    const name = window.prompt('New module name');
+    if (!name) return;
+    axios.post('/modules', { name, language }).then(() => {
+      setModules([...modules, name]);
+    });
+  };
+
   const chooseModule = (m) => {
     setModule(m);
     axios
@@ -82,6 +90,9 @@ function ModuleScreen({
         onChange={(e) => setSearch(e.target.value)}
         placeholder="Search"
       />
+      <button onClick={addModule} style={{ marginLeft: "1rem" }}>
+        Add Module
+      </button>
       <ul>
         {filtered.map((m) => (
           <li key={m}>


### PR DESCRIPTION
## Summary
- query modules from database instead of a hardcoded map
- allow POST `/modules` to create modules
- fetch the list from the backend in the Module screen
- add an `Add Module` button so users can create modules in the UI

## Testing
- `npm run build`
- `python -m py_compile backend/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684e1d245e148331a3162d4347aa67c6