### PR TITLE
Track module completion scores

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -39,3 +39,16 @@ class Error(db.Model):
 
     sentence = db.relationship('Sentence', backref=db.backref('errors', lazy=True))
     module = db.relationship('Module', backref=db.backref('errors', lazy=True))
+
+
+class ModuleResult(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    module_id = db.Column(db.Integer, db.ForeignKey('module.id'), nullable=False)
+    questions_answered = db.Column(db.Integer, nullable=False)
+    questions_correct = db.Column(db.Integer, nullable=False)
+    score = db.Column(db.Float, nullable=False)
+
+    user = db.relationship('User', backref=db.backref('module_results', lazy=True))
+    module = db.relationship('Module', backref=db.backref('module_results', lazy=True))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -392,7 +392,9 @@ def module_results(user_id, language):
     )
     data = {}
     for res, name in rows:
-        data.setdefault(name, []).append(res.score)
+        arr = data.setdefault(name, [])
+        if not arr or arr[-1] != res.score:
+            arr.append(res.score)
     for k in data:
         data[k] = data[k][:3]
     return jsonify(data)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ function App() {
   const [screen, setScreen] = useState("home");
   const [topicOptions, setTopicOptions] = useState([]);
   const [selectedTopics, setSelectedTopics] = useState([]);
+  const [sessionStats, setSessionStats] = useState({ correct: 0, total: 0 });
 
   const login = (selectedUser) => {
     setUser(selectedUser);
@@ -61,7 +62,10 @@ function App() {
           cefr={cefr}
           module={module}
           questionCount={questionCount}
-          onComplete={() => setScreen("summary")}
+          onComplete={(correct) => {
+            setSessionStats({ correct, total: questionCount });
+            setScreen("summary");
+          }}
           home={() => setScreen("home")}
         />
       );
@@ -94,6 +98,9 @@ function App() {
           restart={() => setScreen("practice")}
           home={() => setScreen("home")}
           user={user}
+          stats={sessionStats}
+          module={module}
+          language={language}
         />
       );
     default:

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -15,12 +15,16 @@ function ModuleScreen({
 }) {
   const [modules, setModules] = useState([]);
   const [search, setSearch] = useState("");
+  const [scores, setScores] = useState({});
 
   useEffect(() => {
     if (language) {
       axios.get(`/modules/${language}`).then((res) => setModules(res.data));
+      axios
+        .get(`/results/${user.id}/${language}`)
+        .then((res) => setScores(res.data));
     }
-  }, [language]);
+  }, [language, user]);
 
   const filtered = modules.filter((m) =>
     m.toLowerCase().includes(search.toLowerCase()),
@@ -84,8 +88,35 @@ function ModuleScreen({
       />
       <ul>
         {filtered.map((m) => (
-          <li key={m}>
-            <button onClick={() => chooseModule(m)}>{m}</button>
+          <li key={m} style={{ display: "flex", alignItems: "center" }}>
+            <button onClick={() => chooseModule(m)} style={{ marginRight: "0.5rem" }}>{m}</button>
+            <div style={{ display: "flex" }}>
+              {(scores[m] || []).map((s, idx) => {
+                const pct = Math.round(s * 100);
+                let bg = "red";
+                if (pct > 80) bg = "green";
+                else if (pct >= 60) bg = "orange";
+                return (
+                  <span
+                    key={idx}
+                    style={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: "50%",
+                      backgroundColor: bg,
+                      color: "white",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      marginLeft: 4,
+                      fontSize: 12,
+                    }}
+                  >
+                    {pct}
+                  </span>
+                );
+              })}
+            </div>
           </li>
         ))}
       </ul>

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -6,6 +6,7 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
   const [count, setCount] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
   const [stage, setStage] = useState('question'); // 'question' or 'result'
 
   useEffect(() => {
@@ -30,6 +31,9 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
       translation: answer,
     }).then(res => {
       setResponse(res.data.response);
+      if (res.data.correct === 1) {
+        setCorrectCount(c => c + 1);
+      }
       setCount(c => c + 1);
       setStage('result');
     });
@@ -37,7 +41,7 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
 
   const nextStep = () => {
     if (count >= questionCount) {
-      onComplete();
+      onComplete(correctCount);
     } else {
       setAnswer('');
       setResponse('');

--- a/frontend/src/components/SessionSummary.js
+++ b/frontend/src/components/SessionSummary.js
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
-
-function SessionSummary({ restart, home, user }) {
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+function SessionSummary({ restart, home, user, stats, module, language }) {
   const [filename, setFilename] = useState('session.csv');
   const [errorsFilename, setErrorsFilename] = useState('errors.csv');
+
+  useEffect(() => {
+    axios.post('/session/complete', {
+      user_id: user.id,
+      language,
+      module,
+      questions_answered: stats.total,
+      questions_correct: stats.correct,
+    });
+  }, []);
+
+  const percent = stats.total ? Math.round((stats.correct / stats.total) * 100) : 0;
 
   const download = async () => {
     try {
@@ -40,6 +52,7 @@ function SessionSummary({ restart, home, user }) {
     <div style={{ padding: '2rem' }}>
       <h2>🎉 Congrats!</h2>
       <p>You’ve completed the module.</p>
+      <p>Score: {stats.correct}/{stats.total} ({percent}%)</p>
       <div style={{ marginTop: '1rem' }}>
         <input
           value={filename}

--- a/frontend/src/components/SessionSummary.js
+++ b/frontend/src/components/SessionSummary.js
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 function SessionSummary({ restart, home, user, stats, module, language }) {
   const [filename, setFilename] = useState('session.csv');
   const [errorsFilename, setErrorsFilename] = useState('errors.csv');
+  const savedRef = useRef(false);
 
   useEffect(() => {
+    if (savedRef.current) return;
+    savedRef.current = true;
     axios.post('/session/complete', {
       user_id: user.id,
       language,


### PR DESCRIPTION
## Summary
- add `ModuleResult` database table
- judge correctness after each answer via OpenAI and return a 1/0 flag
- save module results at session completion and expose them through new APIs
- show last three scores for each module when selecting modules
- display session score in summary page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e1e7b58008331be6c9f9b63a8f712