### PR TITLE
Add instructional module option

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -52,3 +52,11 @@ class ModuleResult(db.Model):
 
     user = db.relationship('User', backref=db.backref('module_results', lazy=True))
     module = db.relationship('Module', backref=db.backref('module_results', lazy=True))
+
+
+class Instruction(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    module_id = db.Column(db.Integer, db.ForeignKey('module.id'), nullable=False, unique=True)
+    text = db.Column(db.Text, nullable=False)
+
+    module = db.relationship('Module', backref=db.backref('instruction', uselist=False))

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -59,11 +59,9 @@ def instruction():
     data = request.json
     module = data.get("module")
     language = data.get("language")
-    if not module:
+    if not module and language:
         return jsonify({"error": "module required"}), 400
-    prompt = f"Provide a short instructional module about {module}."
-    if language:
-        prompt += f" Respond in {language}."
+    prompt = f"Provide a short instructional module for an English speaker learning about {module} in {language}."
     current_app.logger.info("OpenAI prompt: %s", prompt)
     response = client.chat.completions.create(
         model="gpt-4o",

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -54,6 +54,28 @@ def add_module():
     return jsonify({"id": module.id, "name": module.name, "language": module.language})
 
 
+@api_blueprint.route("/instruction", methods=["POST"])
+def instruction():
+    data = request.json
+    module = data.get("module")
+    language = data.get("language")
+    if not module:
+        return jsonify({"error": "module required"}), 400
+    prompt = f"Provide a short instructional module about {module}."
+    if language:
+        prompt += f" Respond in {language}."
+    current_app.logger.info("OpenAI prompt: %s", prompt)
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    current_app.logger.info(
+        "OpenAI response: %s", response.choices[0].message.content.strip()
+    )
+    text = response.choices[0].message.content.strip()
+    return jsonify({"instruction": text})
+
+
 def generate_sentence_prompt(cefr, target_language, module):
     return (
         f"Generate a sentence in English for a student at the {cefr} level to translate into {target_language}. Randomize the topic."

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -73,7 +73,7 @@ def instruction():
     if instr and not force:
         return jsonify({"instruction": instr.text})
 
-    prompt = f"Provide a short instructional module about {module_name}."
+    prompt = f"Provide a short instructional module for an English speaker learning about {module_name} in {language}. Provide instruction in English."
     current_app.logger.info("OpenAI prompt: %s", prompt)
     response = client.chat.completions.create(
         model="gpt-4o",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,4 +19,4 @@ Start the development server on port 3000:
 npm start
 ```
 
-The app will talk to the Flask backend on port 5000.
+The app will talk to the Flask backend on port 5050.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "axios": "^1.4.0"
+    "axios": "^1.4.0",
+    "react-markdown": "^9.0.0"
   },
   "scripts": {
     "start": "PORT=3000 react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,11 @@ function App() {
   const [sessionStats, setSessionStats] = useState({ correct: 0, total: 0 });
   const [instruction, setInstruction] = useState("");
 
+  const regenerateInstruction = () =>
+    axios
+      .post("/instruction", { language, module, force: true })
+      .then((res) => setInstruction(res.data.instruction || ""));
+
   const login = (selectedUser) => {
     setUser(selectedUser);
     setScreen("select-language");
@@ -65,6 +70,7 @@ function App() {
       return (
         <InstructionModule
           text={instruction}
+          regenerate={regenerateInstruction}
           next={() => setScreen("practice")}
           home={() => setScreen("home")}
         />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,6 +53,7 @@ function App() {
             setInstruction(text);
             setScreen("instruction");
           }}
+          storeInstruction={(text) => setInstruction(text)}
           startPersonalized={(topics) => {
             setTopicOptions(topics);
             setScreen("personalized-topics");
@@ -75,6 +76,7 @@ function App() {
           language={language}
           cefr={cefr}
           module={module}
+          instruction={instruction}
           questionCount={questionCount}
           onComplete={(correct) => {
             setSessionStats({ correct, total: questionCount });

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import PracticeSession from "./components/PracticeSession";
 import SessionSummary from "./components/SessionSummary";
 import ExportPage from "./components/ExportPage";
 import PersonalizedTopics from "./components/PersonalizedTopics";
+import InstructionModule from "./components/InstructionModule";
 
 function App() {
   const [user, setUser] = useState(null);
@@ -18,6 +19,7 @@ function App() {
   const [topicOptions, setTopicOptions] = useState([]);
   const [selectedTopics, setSelectedTopics] = useState([]);
   const [sessionStats, setSessionStats] = useState({ correct: 0, total: 0 });
+  const [instruction, setInstruction] = useState("");
 
   const login = (selectedUser) => {
     setUser(selectedUser);
@@ -47,10 +49,22 @@ function App() {
           questionCount={questionCount}
           setQuestionCount={setQuestionCount}
           next={() => setScreen("practice")}
+          showInstruction={(text) => {
+            setInstruction(text);
+            setScreen("instruction");
+          }}
           startPersonalized={(topics) => {
             setTopicOptions(topics);
             setScreen("personalized-topics");
           }}
+          home={() => setScreen("home")}
+        />
+      );
+    case "instruction":
+      return (
+        <InstructionModule
+          text={instruction}
+          next={() => setScreen("practice")}
           home={() => setScreen("home")}
         />
       );

--- a/frontend/src/components/InstructionModule.js
+++ b/frontend/src/components/InstructionModule.js
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 
 function InstructionModule({ text, next, home, regenerate }) {
   const [loading, setLoading] = useState(false);
+
   const handleRegenerate = () => {
     setLoading(true);
     regenerate().finally(() => setLoading(false));
@@ -10,8 +12,10 @@ function InstructionModule({ text, next, home, regenerate }) {
   return (
     <div style={{ padding: '2rem' }}>
       <h2>Instruction</h2>
-      <pre>{text}</pre>
-      <div style={{ marginTop: '1rem' }}>
+      <div style={{ marginBottom: '1rem' }}>
+        <ReactMarkdown>{text}</ReactMarkdown>
+      </div>
+      <div>
         <button onClick={handleRegenerate} style={{ marginRight: '1rem' }} disabled={loading}>
           {loading ? 'Regenerating...' : 'Regenerate'}
         </button>

--- a/frontend/src/components/InstructionModule.js
+++ b/frontend/src/components/InstructionModule.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function InstructionModule({ text, next, home }) {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Instruction</h2>
+      <pre>{text}</pre>
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={next} style={{ marginRight: '1rem' }}>Next</button>
+        <button onClick={home}>Home</button>
+      </div>
+    </div>
+  );
+}
+
+export default InstructionModule;

--- a/frontend/src/components/InstructionModule.js
+++ b/frontend/src/components/InstructionModule.js
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-function InstructionModule({ text, next, home }) {
+function InstructionModule({ text, next, home, regenerate }) {
+  const [loading, setLoading] = useState(false);
+  const handleRegenerate = () => {
+    setLoading(true);
+    regenerate().finally(() => setLoading(false));
+  };
+
   return (
     <div style={{ padding: '2rem' }}>
       <h2>Instruction</h2>
       <pre>{text}</pre>
       <div style={{ marginTop: '1rem' }}>
+        <button onClick={handleRegenerate} style={{ marginRight: '1rem' }} disabled={loading}>
+          {loading ? 'Regenerating...' : 'Regenerate'}
+        </button>
         <button onClick={next} style={{ marginRight: '1rem' }}>Next</button>
         <button onClick={home}>Home</button>
       </div>

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -11,6 +11,7 @@ function ModuleScreen({
   setQuestionCount,
   next,
   showInstruction,
+  storeInstruction,
   startPersonalized,
   home,
 }) {
@@ -45,15 +46,17 @@ function ModuleScreen({
     axios
       .post("/sentence/preload", { language, cefr, module: m })
       .then(() => {
-        if (withInstruction) {
-          axios
-            .post("/instruction", { language, module: m })
-            .then((res) => {
-              showInstruction(res.data.instruction || "");
-            });
-        } else {
-          next();
-        }
+        axios
+          .post("/instruction", { language, module: m })
+          .then((res) => {
+            const text = res.data.instruction || "";
+            storeInstruction(text);
+            if (withInstruction) {
+              showInstruction(text);
+            } else {
+              next();
+            }
+          });
       });
   };
 

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -10,12 +10,14 @@ function ModuleScreen({
   questionCount,
   setQuestionCount,
   next,
+  showInstruction,
   startPersonalized,
   home,
 }) {
   const [modules, setModules] = useState([]);
   const [search, setSearch] = useState("");
   const [scores, setScores] = useState({});
+  const [withInstruction, setWithInstruction] = useState(false);
 
   useEffect(() => {
     if (language) {
@@ -42,7 +44,17 @@ function ModuleScreen({
     setModule(m);
     axios
       .post("/sentence/preload", { language, cefr, module: m })
-      .then(() => next());
+      .then(() => {
+        if (withInstruction) {
+          axios
+            .post("/instruction", { language, module: m })
+            .then((res) => {
+              showInstruction(res.data.instruction || "");
+            });
+        } else {
+          next();
+        }
+      });
   };
 
   const personalized = () => {
@@ -87,6 +99,16 @@ function ModuleScreen({
               }
             }}
           />
+        </label>
+      </div>
+      <div style={{ margin: "1rem 0" }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={withInstruction}
+            onChange={() => setWithInstruction(!withInstruction)}
+          />{' '}
+          Start with instruction
         </label>
       </div>
       <input

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -71,6 +71,7 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
     <div style={{ padding: '2rem' }}>
       {showModal && (
         <div
+          onClick={() => setShowModal(false)}  // ← added
           style={{
             position: 'fixed',
             top: 0,
@@ -85,16 +86,37 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
           }}
         >
           <div
+            onClick={(e) => e.stopPropagation()} 
             style={{
+              position: 'relative',
               background: 'white',
               padding: '1rem',
               maxWidth: '80%',
               maxHeight: '80%',
               overflow: 'auto',
+              borderRadius: '8px',
+              boxShadow: '0 4px 12px rgba(0, 0, 0, 0.2)',
             }}
           >
+            {/* X button in top right */}
+            <button
+              onClick={() => setShowModal(false)}
+              style={{
+                position: 'absolute',
+                top: '0.5rem',
+                right: '0.5rem',
+                background: 'transparent',
+                border: 'none',
+                fontSize: '1.5rem',
+                cursor: 'pointer',
+                lineHeight: '1',
+              }}
+              aria-label="Close"
+            >
+              ×
+            </button>
+
             <ReactMarkdown>{instruction}</ReactMarkdown>
-            <button onClick={() => setShowModal(false)}>Close</button>
           </div>
         </div>
       )}

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 
-function PracticeSession({ user, language, cefr, module, questionCount, onComplete, home }) {
+function PracticeSession({ user, language, cefr, module, instruction, questionCount, onComplete, home }) {
   const [sentence, setSentence] = useState('');
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
@@ -11,6 +11,7 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
   const [count, setCount] = useState(0);
   const [correctCount, setCorrectCount] = useState(0);
   const [stage, setStage] = useState('question'); // 'question' or 'result'
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     fetchSentence();
@@ -67,6 +68,35 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
 
   return (
     <div style={{ padding: '2rem' }}>
+      {showModal && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+        >
+          <div
+            style={{
+              background: 'white',
+              padding: '1rem',
+              maxWidth: '80%',
+              maxHeight: '80%',
+              overflow: 'auto',
+            }}
+          >
+            <pre>{instruction}</pre>
+            <button onClick={() => setShowModal(false)}>Close</button>
+          </div>
+        </div>
+      )}
       {stage === 'question' && (
         <>
           <h3>Translate:</h3>
@@ -106,6 +136,9 @@ function PracticeSession({ user, language, cefr, module, questionCount, onComple
       )}
       <div>Progress: {count}/{questionCount}</div>
       <div style={{ marginTop: '1rem' }}>
+        <button onClick={() => setShowModal(true)} style={{ marginRight: '1rem' }}>
+          Instruction
+        </button>
         <button onClick={home}>Home</button>
       </div>
     </div>

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import ReactMarkdown from 'react-markdown';
 
 function PracticeSession({ user, language, cefr, module, instruction, questionCount, onComplete, home }) {
   const [sentence, setSentence] = useState('');
@@ -92,7 +93,7 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
               overflow: 'auto',
             }}
           >
-            <pre>{instruction}</pre>
+            <ReactMarkdown>{instruction}</ReactMarkdown>
             <button onClick={() => setShowModal(false)}>Close</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `/instruction` endpoint to backend
- let module screen optionally show an instructional module first
- store instruction text and show `InstructionModule` screen

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `python -m py_compile routes.py app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_684f14298bd88331959f69aaa60b5799