### PR TITLE
Add correctness headers after sentence submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+frontend/node_modules/
+frontend/build/
+

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -237,8 +237,8 @@ def submit_sentence():
         f"Module topic: {module_name}.\n"
         f"English sentence: {english}\n"
         f"Learner translation: {translation}\n"
-        "Ignoring spelling or vocabulary mistakes, did the learner correctly "
-        "convey the meaning and use the module concept? Respond only with 1 or 0."
+        "Ignoring all mistakes outside of {module_name} (ex. ignoring spelling, prepositions, number agreement, and articles), did the learner correctly "
+        "convey the meaning and use the module concept {module_name}? Respond only with 1 (for yes) or 0 (for no)."
     )
     current_app.logger.info("OpenAI prompt: %s", judge_prompt)
     judge_resp = client.chat.completions.create(

--- a/frontend/src/components/ErrorReviewSession.js
+++ b/frontend/src/components/ErrorReviewSession.js
@@ -10,6 +10,16 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
   const [correctCount, setCorrectCount] = useState(0);
   const [correct, setCorrect] = useState(null);
 
+  const toggleAssessment = () => {
+    if (correct === null) return;
+    if (correct) {
+      setCorrectCount(c => Math.max(0, c - 1));
+    } else {
+      setCorrectCount(c => c + 1);
+    }
+    setCorrect(!correct);
+  };
+
   const currentError = errors[index];
 
   useEffect(() => {
@@ -73,7 +83,17 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
       )}
       {stage === 'result' && (
         <>
-          <h3>{correct ? 'Correct! 🎉' : 'Incorrect'}</h3>
+          <h3>
+            {correct ? 'Correct! 🎉' : 'Incorrect'}
+            {correct !== null && (
+              <button
+                onClick={toggleAssessment}
+                style={{ marginLeft: '1rem', fontSize: '0.8rem' }}
+              >
+                Change assessment
+              </button>
+            )}
+          </h3>
           <pre>{response}</pre>
           <button onClick={next}>Next</button>
         </>

--- a/frontend/src/components/ErrorReviewSession.js
+++ b/frontend/src/components/ErrorReviewSession.js
@@ -8,6 +8,7 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
   const [response, setResponse] = useState('');
   const [stage, setStage] = useState('question');
   const [correctCount, setCorrectCount] = useState(0);
+  const [correct, setCorrect] = useState(null);
 
   const currentError = errors[index];
 
@@ -41,6 +42,7 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
         if (res.data.correct === 1) {
           setCorrectCount(c => c + 1);
         }
+        setCorrect(res.data.correct === 1);
         setStage('result');
       });
   };
@@ -52,6 +54,7 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
       setIndex(i => i + 1);
       setAnswer('');
       setResponse('');
+      setCorrect(null);
       setStage('question');
     }
   };
@@ -70,6 +73,7 @@ function ErrorReviewSession({ user, language, cefr, errors, onComplete, home }) 
       )}
       {stage === 'result' && (
         <>
+          <h3>{correct ? 'Correct! 🎉' : 'Incorrect'}</h3>
           <pre>{response}</pre>
           <button onClick={next}>Next</button>
         </>

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -13,6 +13,7 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
   const [correctCount, setCorrectCount] = useState(0);
   const [stage, setStage] = useState('question'); // 'question' or 'result'
   const [showModal, setShowModal] = useState(false);
+  const [correct, setCorrect] = useState(null);
   const [vocab, setVocab] = useState([]);
 
   useEffect(() => {
@@ -46,6 +47,7 @@ const submit = () => {
         setCorrectCount(c => c + 1);
       }
 
+      setCorrect(res.data.correct === 1);
       setCount(c => c + 1);
       setStage('result');
     });
@@ -76,6 +78,7 @@ const submit = () => {
           setChecked([]);
           setSentenceId(null);
           setVocab([]);
+          setCorrect(null);
           fetchSentence();
         }
       });
@@ -144,6 +147,7 @@ const submit = () => {
       )}
       {stage === 'result' && (
         <>
+          <h3>{correct ? 'Correct! 🎉' : 'Incorrect'}</h3>
           <div style={{ whiteSpace: 'pre-wrap' }}>
             {response.split(/(\b)/).map((tok, idx) => {
               const clean = tok.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ'-]/g, '');

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -16,6 +16,16 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
   const [correct, setCorrect] = useState(null);
   const [vocab, setVocab] = useState([]);
 
+  const toggleAssessment = () => {
+    if (correct === null) return;
+    if (correct) {
+      setCorrectCount(c => Math.max(0, c - 1));
+    } else {
+      setCorrectCount(c => c + 1);
+    }
+    setCorrect(!correct);
+  };
+
   useEffect(() => {
     fetchSentence();
   }, []);
@@ -147,7 +157,17 @@ const submit = () => {
       )}
       {stage === 'result' && (
         <>
-          <h3>{correct ? 'Correct! 🎉' : 'Incorrect'}</h3>
+          <h3>
+            {correct ? 'Correct! 🎉' : 'Incorrect'}
+            {correct !== null && (
+              <button
+                onClick={toggleAssessment}
+                style={{ marginLeft: '1rem', fontSize: '0.8rem' }}
+              >
+                Change assessment
+              </button>
+            )}
+          </h3>
           <div style={{ whiteSpace: 'pre-wrap' }}>
             {response.split(/(\b)/).map((tok, idx) => {
               const clean = tok.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ'-]/g, '');


### PR DESCRIPTION
## Summary
- show a `Correct! 🎉` or `Incorrect` heading after sentence and error submissions
- track answer correctness in state
- ignore build and node_modules

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f4af7d9a483319af2ae8a75e5ab24