### PR TITLE
Improve module editing UI and generation prompts

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ function App() {
   const [chapter, setChapter] = useState(null);
   const [cefr, setCefr] = useState("A1");
   const [module, setModule] = useState("");
+  const [moduleDescription, setModuleDescription] = useState("");
   const [questionCount, setQuestionCount] = useState(5);
   const [screen, setScreen] = useState("home");
   const [topicOptions, setTopicOptions] = useState([]);
@@ -88,6 +89,7 @@ function App() {
           cefr={cefr}
           setCefr={setCefr}
           setModule={setModule}
+          setModuleDescription={setModuleDescription}
           questionCount={questionCount}
           setQuestionCount={setQuestionCount}
           next={() => setScreen("practice")}
@@ -120,6 +122,7 @@ function App() {
           language={language}
           cefr={cefr}
           module={module}
+          moduleDescription={moduleDescription}
           instruction={instruction}
           questionCount={questionCount}
           onComplete={(correct) => {

--- a/frontend/src/components/ModuleScreen.js
+++ b/frontend/src/components/ModuleScreen.js
@@ -129,6 +129,7 @@ function ModuleScreen({
         {filtered.map((m) => {
           const moduleScores = scores[m.name] || [];
           const avg = moduleScores.length > 0 ? moduleScores.reduce((a, b) => a + b, 0) / moduleScores.length : null;
+
           return (
             <div
               key={m.id}
@@ -138,55 +139,117 @@ function ModuleScreen({
                 padding: "1rem",
                 margin: "0.5rem",
                 width: 300,
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+                position: "relative",
               }}
             >
-              <div className="module-header">
-                <div className="module-name" style={{ fontWeight: "bold" }}>{m.name}</div>
+              {/* Top right edit/delete */}
+              <div style={{ position: "absolute", top: 8, right: 8, display: "flex", gap: "0.5rem" }}>
+                <span
+                  onClick={() => setFormModal(m)}
+                  style={{
+                    color: "#007BFF",
+                    cursor: "pointer",
+                    fontSize: "0.9rem",
+                  }}
+                >
+                  Edit
+                </span>
+                <span
+                  onClick={() => {
+                    if (window.confirm('Delete module?')) {
+                      axios.delete(`/modules/${m.id}`).then(() => {
+                        setModules(modules.filter((x) => x.id !== m.id));
+                      });
+                    }
+                  }}
+                  style={{ cursor: "pointer" }}
+                  title="Delete"
+                >
+                  🗑️
+                </span>
               </div>
-              <div className="module-meta" style={{ marginBottom: "0.5rem" }}>
+
+              <div>
+                <div className="module-name" style={{ fontWeight: "bold", marginBottom: "0.5rem" }}>
+                  {m.name}
+                </div>
+
                 {avg !== null && (
-                  <div className="progress-info">Progress: {avg.toFixed(0)}%</div>
-                )}
-              </div>
-              {avg !== null && (
-                <div className="progress-bar" style={{ height: 10, background: "#eee", marginBottom: "0.5rem" }}>
-                  <div className="progress-fill" style={{ width: `${avg}%`, background: "#ff9500", height: "100%" }} />
-                </div>
-              )}
-              {moduleScores.length > 0 && (
-                <div className="scores" style={{ display: "flex", marginBottom: "0.5rem" }}>
-                  {moduleScores.map((s, idx) => (
-                    <div key={idx} className="score" style={{ marginRight: 4 }}>{s.toFixed(0)}</div>
-                  ))}
-                </div>
-              )}
-              <p>
-                {(m.description || "").slice(0, 80)}
-                {m.description && m.description.length > 80 && (
                   <>
-                    ...{' '}
-                    <span
-                      style={{ color: "blue", cursor: "pointer" }}
-                      onClick={() => setModal(m)}
+                    <div className="progress-info" style={{ marginBottom: "0.25rem" }}>
+                      Progress: {avg.toFixed(0)}%
+                    </div>
+                    <div
+                      className="progress-bar"
+                      style={{ height: 10, background: "#eee", marginBottom: "0.5rem" }}
                     >
-                      see more
-                    </span>
+                      <div
+                        className="progress-fill"
+                        style={{
+                          width: `${avg}%`,
+                          background: "#ff9500",
+                          height: "100%",
+                        }}
+                      />
+                    </div>
                   </>
                 )}
-              </p>
-              <button onClick={() => chooseModule(m)} style={{ marginRight: '0.5rem' }}>Select</button>
-              <button onClick={() => setFormModal(m)} style={{ marginRight: '0.5rem' }}>Edit</button>
-              <button
-                onClick={() => {
-                  if (window.confirm('Delete module?')) {
-                    axios.delete(`/modules/${m.id}`).then(() => {
-                      setModules(modules.filter((x) => x.id !== m.id));
-                    });
-                  }
-                }}
-              >
-                Delete
-              </button>
+
+                {moduleScores.length > 0 && (
+                  <div className="scores" style={{ display: "flex", marginBottom: "0.5rem" }}>
+                    {moduleScores.slice(-3).map((s, idx) => {
+                      let bgColor = "#ccc";
+                      if (s * 100 >= 80) bgColor = "#4CAF50";
+                      else if (s * 100 >= 60) bgColor = "#FFEB3B";
+                      else bgColor = "#F44336";
+
+                      return (
+                        <div
+                          key={idx}
+                          style={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            backgroundColor: bgColor,
+                            color: "#000",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            fontSize: 12,
+                            fontWeight: "bold",
+                            marginRight: 4,
+                          }}
+                        >
+                          {(s * 100).toFixed(0)}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                <p>
+                  {(m.description || "").slice(0, 80)}
+                  {m.description && m.description.length > 80 && (
+                    <>
+                      ...{" "}
+                      <span
+                        style={{ color: "blue", cursor: "pointer" }}
+                        onClick={() => setModal(m)}
+                      >
+                        see more
+                      </span>
+                    </>
+                  )}
+                </p>
+              </div>
+
+              {/* Bottom right Start Study Session */}
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button onClick={() => chooseModule(m)}>Start Study Session</button>
+              </div>
             </div>
           );
         })}
@@ -203,11 +266,20 @@ function ModuleScreen({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            zIndex: 1000,
           }}
           onClick={() => setModal(null)}
         >
           <div
-            style={{ background: "white", padding: "1rem", maxWidth: 400 }}
+            style={{
+              background: "white",
+              padding: "1rem",
+              maxWidth: 400,
+              maxHeight: "80vh",
+              overflowY: "auto",
+              borderRadius: "8px",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+            }}
             onClick={(e) => e.stopPropagation()}
           >
             <h3>{modal.name}</h3>
@@ -228,11 +300,21 @@ function ModuleScreen({
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
+            zIndex: 1000,
           }}
           onClick={() => setFormModal(null)}
         >
           <div
-            style={{ background: "white", padding: "1rem", maxWidth: 400 }}
+            style={{
+              background: "white",
+              padding: "1rem",
+              maxWidth: 400,
+              maxHeight: "80vh",
+              overflowY: "auto",
+              borderRadius: "8px",
+              boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+              width: "100%",
+            }}
             onClick={(e) => e.stopPropagation()}
           >
             <h3>{formModal.id ? "Edit Module" : "Add Module"}</h3>
@@ -254,6 +336,7 @@ function ModuleScreen({
                 onChange={(e) =>
                   setFormModal({ ...formModal, description: e.target.value })
                 }
+                style={{ width: "100%" }}
               />
             </div>
             <div style={{ marginBottom: "0.5rem" }}>

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -188,20 +188,27 @@ const submit = () => {
             )}
           </h3>
           <div style={{ whiteSpace: 'pre-wrap' }}>
-            {response.split(/(\b)/).map((tok, idx) => {
-              const clean = tok.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ'-]/g, '');
-              if (!clean) return tok;
-              const selected = vocab.includes(clean);
+            {response.split(/(\s+|[.,!?;:"“”«»()])/).map((tok, idx) => {
+              const visibleWord = tok;
+
+              // Match words including accents and hyphens (but not trailing punctuation or asterisks)
+              const cleaned = tok
+                .replace(/^[^A-Za-zÀ-ÖØ-öø-ÿ'-]+/, '')  // remove leading non-letter
+                .replace(/[^A-Za-zÀ-ÖØ-öø-ÿ'-]+$/, ''); // remove trailing non-letter
+
+              if (!cleaned) return tok;
+
+              const selected = vocab.includes(cleaned);
               return (
                 <span
                   key={idx}
-                  onClick={() => toggleWord(clean)}
+                  onClick={() => toggleWord(cleaned)}
                   style={{
                     backgroundColor: selected ? 'lightblue' : 'transparent',
                     cursor: 'pointer',
                   }}
                 >
-                  {tok}
+                  {visibleWord}
                 </span>
               );
             })}

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import ReactMarkdown from 'react-markdown';
 
-function PracticeSession({ user, language, cefr, module, instruction, questionCount, onComplete, home }) {
+function PracticeSession({ user, language, cefr, module, moduleDescription, instruction, questionCount, onComplete, home }) {
   const [sentence, setSentence] = useState('');
   const [answer, setAnswer] = useState('');
   const [response, setResponse] = useState('');
@@ -31,7 +31,7 @@ function PracticeSession({ user, language, cefr, module, instruction, questionCo
   }, []);
 
   const fetchSentence = () => {
-    axios.post('/sentence/generate', { language, cefr, module })
+    axios.post('/sentence/generate', { language, cefr, module, module_description: moduleDescription })
       .then(res => {
         setSentence(res.data.sentence);
         setStage('question');

--- a/frontend/src/components/PracticeSession.js
+++ b/frontend/src/components/PracticeSession.js
@@ -151,7 +151,26 @@ const submit = () => {
         <>
           <h3>Translate:</h3>
           <p>{sentence}</p>
-          <input value={answer} onChange={e => setAnswer(e.target.value)} />
+          <textarea
+            spellCheck={true}
+            value={answer}
+            onChange={e => setAnswer(e.target.value)}
+            rows={4}
+            style={{
+              width: '100%',
+              padding: '0.75rem',
+              fontSize: '1rem',
+              borderRadius: '6px',
+              border: '1px solid #ccc',
+              marginBottom: '1rem',
+              resize: 'vertical',
+              fontFamily: 'inherit',
+              lineHeight: '1.4',
+              WebkitUserModify: 'read-write',
+              userSelect: 'text',
+            }}
+            placeholder="Type your answer here..."
+          />
           <button onClick={submit}>Submit</button>
         </>
       )}


### PR DESCRIPTION
## Summary
- allow adding module descriptions to sentence generation prompts
- send module description from the frontend when selecting a module
- add module description editing modal with Markdown preview
- display recent scores and wider cards on the module selection screen
- carry module description into practice sessions

## Testing
- `npm install --prefix frontend`
- `npm run build --prefix frontend`
- `python -m py_compile backend/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68549030d47883318903067fe59e5a84